### PR TITLE
Fix SEO-breaking error in `url`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   The Hotels Licensing Board website is an easy platform to search for types of hotels and 
   accommodations possessing a valid hotel licence and their locations
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "www.hlb.gov.sg" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://www.hlb.gov.sg" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll
 


### PR DESCRIPTION
Change url from `www.hlb.gov.sg` to `https://www.hlb.gov.sg` to allow `jekyll-sitemap` plugin to generate valid sitemap.xml